### PR TITLE
Fix missing closing tag in about page

### DIFF
--- a/blog-technicien-informatique/about.html
+++ b/blog-technicien-informatique/about.html
@@ -163,7 +163,7 @@
         </div>
 
         <aside class="about-card">
-          <h2>Compétences (celles qui sauvent des nuits)</h2
+          <h2>Compétences (celles qui sauvent des nuits)</h2>
           <div>
             <span class="pill">Linux</span>
             <span class="pill">Réseaux</span>


### PR DESCRIPTION
## Summary
- close the Compétences section heading tag in about.html to restore valid markup

## Testing
- npx html-validate about.html *(fails: npm error 403 fetching html-validate from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6e0587b08326b17b89467a8a063d